### PR TITLE
Fix full linkage

### DIFF
--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -45,14 +45,7 @@ module FastJsonapi
         empty_case = relationship_type == :has_many ? [] : nil
 
         output_hash[key] = {}
-        
-        # Always serialize :data when relationship is included, even for lazy_load_data relationships
-        should_serialize_data = included || !lazy_load_data
-        
-        if should_serialize_data
-          data_result = ids_hash_from_record_and_relationship(record, serialization_params)
-          output_hash[key][:data] = data_result || empty_case
-        end
+        output_hash[key][:data] = ids_hash_from_record_and_relationship(record, serialization_params) || empty_case unless lazy_load_data && !included
 
         add_meta_hash(record, serialization_params, output_hash) if meta.present?
         add_links_hash(record, serialization_params, output_hash) if links.present?

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -52,7 +52,6 @@ module FastJsonapi
         if should_serialize_data
           data_result = ids_hash_from_record_and_relationship(record, serialization_params)
           output_hash[key][:data] = data_result || empty_case
-        else
         end
 
         add_meta_hash(record, serialization_params, output_hash) if meta.present?

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -57,7 +57,7 @@ module FastJsonapi
         relationships = {} if fieldset == []
 
         relationships.each_with_object({}) do |(key, relationship), hash|
-          included = includes_list.present? && (includes_list.include?(key) || includes_list.any? { |include_item| include_item.to_s.start_with?("#{key}.") })
+          included = includes_list.present? && includes_list.include?(key)
           relationship.serialize(record, included, params, hash)
         end
       end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -204,7 +204,7 @@ module FastJsonapi
             # If new_includes_list is empty, we're at a leaf level of the include path
             # but we still need to mark the final relationship as included so it serializes data
             # For example: with 'mpi_categories.sub_categories', when processing an included mpi_category,
-            # its sub_categories relationship should be included=true to serialize data
+            # its sub_categories relationship should be considered as included to serialize the data key.
             if new_includes_list.empty?
               # The include_item.first is the relationship name that should be included
               relationship_key = include_item.first

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -57,7 +57,7 @@ module FastJsonapi
         relationships = {} if fieldset == []
 
         relationships.each_with_object({}) do |(key, relationship), hash|
-          included = includes_list.present? && includes_list.include?(key)
+          included = includes_list.present? && (includes_list.include?(key) || includes_list.any? { |include_item| include_item.to_s.start_with?("#{key}.") })
           relationship.serialize(record, included, params, hash)
         end
       end
@@ -67,20 +67,28 @@ module FastJsonapi
       end
 
       def record_hash(record, fieldset, includes_list, params = {})
+        # Parse includes list to get the root relationship keys that should be included
+        # includes_list might be raw array like [:'comments.author'] or already parsed hash like {author: Set.new([])}
+        parsed_includes = if includes_list.present?
+          includes_list.is_a?(Hash) ? includes_list.keys : parse_includes_list(includes_list).keys
+        else
+          []
+        end
+        
         if cache_store_instance
           cache_opts = record_cache_options(cache_store_options, fieldset, includes_list, params)
           record_hash = cache_store_instance.fetch(record, **cache_opts) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
-            temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize, fieldset, includes_list, params) if cachable_relationships_to_serialize.present?
+            temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize, fieldset, parsed_includes, params) if cachable_relationships_to_serialize.present?
             temp_hash[:links] = links_hash(record, params) if data_links.present?
             temp_hash
           end
-          record_hash[:relationships] = (record_hash[:relationships] || {}).merge(relationships_hash(record, uncachable_relationships_to_serialize, fieldset, includes_list, params)) if uncachable_relationships_to_serialize.present?
+          record_hash[:relationships] = (record_hash[:relationships] || {}).merge(relationships_hash(record, uncachable_relationships_to_serialize, fieldset, parsed_includes, params)) if uncachable_relationships_to_serialize.present?
         else
           record_hash = id_hash(id_from_record(record, params), record_type, true)
           record_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
-          record_hash[:relationships] = relationships_hash(record, nil, fieldset, includes_list, params) if relationships_to_serialize.present?
+          record_hash[:relationships] = relationships_hash(record, nil, fieldset, parsed_includes, params) if relationships_to_serialize.present?
           record_hash[:links] = links_hash(record, params) if data_links.present?
         end
 
@@ -192,8 +200,18 @@ module FastJsonapi
             next if known_included_objects.include?(code)
 
             known_included_objects << code
-
             new_includes_list = parse_includes_list(include_item.last)
+            
+            # If new_includes_list is empty, we're at a leaf level of the include path
+            # but we still need to mark the final relationship as included so it serializes data
+            # For example: with 'mpi_categories.sub_categories', when processing an included mpi_category,
+            # its sub_categories relationship should be included=true to serialize data
+            if new_includes_list.empty?
+              # The include_item.first is the relationship name that should be included
+              relationship_key = include_item.first
+              new_includes_list[relationship_key] = Set.new
+            end
+            
             included_records << serializer.record_hash(inc_obj, fieldsets[record_type], new_includes_list, params)
           end
         end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -67,7 +67,6 @@ module FastJsonapi
       end
 
       def record_hash(record, fieldset, includes_list, params = {})
-        # Parse includes list to get the root relationship keys that should be included
         # includes_list might be raw array like [:'comments.author'] or already parsed hash like {author: Set.new([])}
         parsed_includes = if includes_list.present?
           includes_list.is_a?(Hash) ? includes_list.keys : parse_includes_list(includes_list).keys

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -106,6 +106,17 @@ class MovieSerializer
   end
 end
 
+class MovieSerializerWithLazy
+  include JSONAPI::Serializer
+
+  set_type :movie
+
+  attributes :name
+  
+  has_many :actors, lazy_load_data: true, serializer: ActorSerializer
+  belongs_to :owner, lazy_load_data: true, serializer: UserSerializer
+end
+
 module Cached
   class MovieSerializer < ::MovieSerializer
     cache_options(


### PR DESCRIPTION
The gem did not serialize the relationships data key according to full linkage compliance. Here is a definition we can find in the [JSON:API spec](https://jsonapi.org/format/#document-compound-documents).

> Every included resource object MUST be identified via a chain of relationships originating in a document’s primary data. This means that compound documents require “full linkage” and that no resource object can be included without a direct or indirect relationship to the document’s primary data.

  1. Prefix match logic → Fixes missing data key for intermediate relationships (like comments in comments.author)
  2. Leaf-level inclusion logic → Fixes missing data key for final relationships (like sub_categories in mpi_categories.sub_categories)
  3. Empty collection check → Prevents ActiveRecord strict loading violations on empty associations

Once this is merge, we will be able to update the gem in https://github.com/Kimoby/kimoby-rails/pull/19312